### PR TITLE
Update Deflate.cs

### DIFF
--- a/itext/itext.io/itext/io/util/zlib/Deflate.cs
+++ b/itext/itext.io/itext/io/util/zlib/Deflate.cs
@@ -1383,7 +1383,7 @@ namespace System.util.zlib {
             pending_buf = new byte[lit_bufsize*4];
             pending_buf_size = lit_bufsize*4;
 
-            d_buf = lit_bufsize/2;
+            d_buf = lit_bufsize;
             l_buf = (1+2)*lit_bufsize;
 
             this.level = level;


### PR DESCRIPTION
fixed a bug in calculating the size of the pending buffer.
In certain PDF generation scenarios, this bug can lead to the following problems:
```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
at System.util.zlib.Tree.d_code(Int32 dist)
```
