### PR TITLE
feat: resolve css variables

### DIFF
--- a/itext/itext.styledxmlparser/itext/styledxmlparser/css/resolve/CssInheritance.cs
+++ b/itext/itext.styledxmlparser/itext/styledxmlparser/css/resolve/CssInheritance.cs
@@ -66,6 +66,12 @@ namespace iText.StyledXmlParser.Css.Resolve {
         /// <param name="cssProperty">the CSS property</param>
         /// <returns>true, if the property is inheritable</returns>
         public virtual bool IsInheritable(String cssProperty) {
+
+            // Always inherit CSS variables
+            if (cssProperty.StartsWith("--")) {
+                return true;
+            }
+
             return INHERITABLE_PROPERTIES.Contains(cssProperty);
         }
     }


### PR DESCRIPTION
Current style sheet logic ignores CSS variables, and can break when parsing them.

This PR properly resolves CSS variables.
