### PR TITLE
docs: add 20 language links of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="right">
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=en">English</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=zh-CN">简体中文</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=zh-TW">繁體中文</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=ja">日本語</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=ko">한국어</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=hi">हिन्दी</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=th">ไทย</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=fr">Français</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=de">Deutsch</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=es">Español</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=it">Itapano</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=ru">Русский</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=pt">Português</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=nl">Nederlands</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=pl">Polski</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=ar">العربية</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=fa">فارسی</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=tr">Türkçe</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=vi">Tiếng Việt</a></p>
+        <p><a href="https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=id">Bahasa Indonesia</a></p>
+      </div>
+    </div>
+  </details>
+</div>
+
 <p align="center">
     <img src="./assets/iText_Logo_Small.png" alt="Logo iText">
 </p>


### PR DESCRIPTION
PR adds 20 languages link to the README and user can easily access translated README, supports google/bing multiple languages SEO search.

Page demo: https://openaitx.github.io/view.html?user=itext&project=itext-dotnet&lang=ja

> OpenAiTx is free and open-source:  https://github.com/OpenAiTx/OpenAiTx 

 ![Image](https://github.com/user-attachments/assets/1a95bf8c-ab15-4a32-a6fa-0acfdb8ff26f)